### PR TITLE
Add real price data to simulator

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import './App.css'
 import MenuBar from './components/MenuBar'
 import CryptoCard from './components/CryptoCard'
+import TradeSimulator from './components/TradeSimulator'
 
 function App() {
 
@@ -9,6 +10,7 @@ function App() {
       <MenuBar />
       <div className="ml-[10%] mr-[10%]">
        <CryptoCard />
+       <TradeSimulator />
       </div>
     </>
   )

--- a/src/components/CryptoCard/index.tsx
+++ b/src/components/CryptoCard/index.tsx
@@ -1,15 +1,48 @@
+import { useEffect, useState } from "react";
 import CryptoCharts from "../CryptoCharts";
 import "./styles.css"
 
-const CryptoCard:React.FC = () => {
-    return (
-    <div >
-        <img src="https://s2.coinmarketcap.com/static/img/coins/64x64/1.png" alt="bitcoin chart" />
-        <h1 className="text-[2rem] font-semibold">Preço do Bitcoin (BTC)</h1>
-        <p>BTC para USD: 1 Bitcoin é igual a $83,716.48 USD+0.9%</p>
-        <CryptoCharts />
-    </div>
+const CryptoCard: React.FC = () => {
+  const [prices, setPrices] = useState<{ bitcoin: number; ethereum: number }>({
+    bitcoin: 0,
+    ethereum: 0,
+  });
+
+  useEffect(() => {
+    fetch(
+      "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum&vs_currencies=usd"
     )
+      .then((res) => res.json())
+      .then((data) => {
+        setPrices({
+          bitcoin: data.bitcoin.usd,
+          ethereum: data.ethereum.usd,
+        });
+      })
+      .catch(() => {
+        // ignore fetch errors
+      });
+  }, []);
+
+  return (
+    <div>
+      <img
+        src="https://s2.coinmarketcap.com/static/img/coins/64x64/1.png"
+        alt="bitcoin chart"
+      />
+      <h1 className="text-[2rem] font-semibold">Preço do Bitcoin (BTC)</h1>
+      <p>
+        BTC para USD: 1 Bitcoin é igual a $
+        {prices.bitcoin ? prices.bitcoin.toFixed(2) : "..."} USD
+      </p>
+      <h1 className="text-[2rem] font-semibold mt-4">Preço do Ethereum (ETH)</h1>
+      <p>
+        ETH para USD: 1 Ethereum é igual a $
+        {prices.ethereum ? prices.ethereum.toFixed(2) : "..."} USD
+      </p>
+      <CryptoCharts />
+    </div>
+  );
 }
 
 export default CryptoCard;

--- a/src/components/TradeSimulator/index.tsx
+++ b/src/components/TradeSimulator/index.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from "react";
+import "./styles.css";
+
+const TradeSimulator: React.FC = () => {
+  const [usdBalance, setUsdBalance] = useState<number>(1000);
+  const [balances, setBalances] = useState<{ bitcoin: number; ethereum: number }>({
+    bitcoin: 0,
+    ethereum: 0,
+  });
+  const [amount, setAmount] = useState<string>("");
+  const [selectedCoin, setSelectedCoin] = useState<"bitcoin" | "ethereum">(
+    "bitcoin"
+  );
+  const [prices, setPrices] = useState<{ bitcoin: number; ethereum: number }>({
+    bitcoin: 0,
+    ethereum: 0,
+  });
+
+  useEffect(() => {
+    fetch(
+      "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum&vs_currencies=usd"
+    )
+      .then((res) => res.json())
+      .then((data) => {
+        setPrices({
+          bitcoin: data.bitcoin.usd,
+          ethereum: data.ethereum.usd,
+        });
+      })
+      .catch(() => {
+        // ignore fetch errors
+      });
+  }, []);
+
+  const buy = () => {
+    const amountNum = parseFloat(amount);
+    if (isNaN(amountNum) || amountNum <= 0) return;
+    const price = prices[selectedCoin];
+    const cost = amountNum * price;
+    if (cost > usdBalance) {
+      alert("Saldo insuficiente");
+      return;
+    }
+    setUsdBalance(usdBalance - cost);
+    setBalances({
+      ...balances,
+      [selectedCoin]: balances[selectedCoin] + amountNum,
+    });
+    setAmount("");
+  };
+
+  const sell = () => {
+    const amountNum = parseFloat(amount);
+    if (isNaN(amountNum) || amountNum <= 0) return;
+    if (amountNum > balances[selectedCoin]) {
+      alert("Você não possui essa quantidade de " + selectedCoin.toUpperCase());
+      return;
+    }
+    const price = prices[selectedCoin];
+    setUsdBalance(usdBalance + amountNum * price);
+    setBalances({
+      ...balances,
+      [selectedCoin]: balances[selectedCoin] - amountNum,
+    });
+    setAmount("");
+  };
+
+  return (
+    <div className="trade-simulator mt-8">
+      <h2 className="text-xl font-semibold mb-2">Simulador de Operações</h2>
+      <p>Saldo em USD: ${usdBalance.toFixed(2)}</p>
+      <p>
+        BTC: {balances.bitcoin.toFixed(8)} | ETH: {balances.ethereum.toFixed(8)}
+      </p>
+      <p>
+        Preço atual {selectedCoin.toUpperCase()}: $
+        {prices[selectedCoin] ? prices[selectedCoin].toFixed(2) : "..."}
+      </p>
+      <div className="flex gap-2 mt-4">
+        <select
+          value={selectedCoin}
+          onChange={(e) => setSelectedCoin(e.target.value as "bitcoin" | "ethereum")}
+          className="text-black border p-1"
+        >
+          <option value="bitcoin">BTC</option>
+          <option value="ethereum">ETH</option>
+        </select>
+        <input
+          type="number"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder={`Quantidade de ${selectedCoin.toUpperCase()}`}
+          className="border p-1 text-black"
+        />
+        <button onClick={buy} className="bg-green-600 px-2 py-1 rounded">Comprar</button>
+        <button onClick={sell} className="bg-red-600 px-2 py-1 rounded">Vender</button>
+      </div>
+    </div>
+  );
+};
+
+export default TradeSimulator;

--- a/src/components/TradeSimulator/styles.css
+++ b/src/components/TradeSimulator/styles.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";


### PR DESCRIPTION
## Summary
- fetch Bitcoin and Ethereum prices from CoinGecko
- update `TradeSimulator` to operate on real-time prices for BTC and ETH
- show live prices on `CryptoCard`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: react and other modules not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7a5e86ac832fb98d5e57c21cc6ea